### PR TITLE
Updating binder links to point to main repo

### DIFF
--- a/chapter10/10.4.ipynb
+++ b/chapter10/10.4.ipynb
@@ -6,7 +6,7 @@
     "id": "EI3PhtVB5Ui_"
    },
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter10/10.4.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter10/10.4.ipynb)\n",
     "\n",
     "# Temporally localized signals"
    ]

--- a/chapter10/10.4.md
+++ b/chapter10/10.4.md
@@ -14,7 +14,7 @@ kernelspec:
 
 +++ {"id": "EI3PhtVB5Ui_"}
 
-[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter10/10.4.ipynb)
+[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter10/10.4.ipynb)
 
 # Temporally localized signals
 

--- a/chapter10/Chapter10.2.5.ipynb
+++ b/chapter10/Chapter10.2.5.ipynb
@@ -6,7 +6,7 @@
     "id": "RY3UTJn5xS61"
    },
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter10/Chapter10.2.5.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter10/Chapter10.2.5.ipynb)\n",
     "\n",
     "# Digital Filtering"
    ]

--- a/chapter10/Chapter10.2.5.md
+++ b/chapter10/Chapter10.2.5.md
@@ -14,7 +14,7 @@ kernelspec:
 
 +++ {"id": "RY3UTJn5xS61"}
 
-[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter10/Chapter10.2.5.ipynb)
+[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter10/Chapter10.2.5.ipynb)
 
 # Digital Filtering
 

--- a/chapter10/Chapter10.2.ipynb
+++ b/chapter10/Chapter10.2.ipynb
@@ -6,7 +6,7 @@
     "id": "W_l-7O_Ed1MV"
    },
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter10/Chapter10.2.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter10/Chapter10.2.ipynb)\n",
     "\n",
     "# Modeling Toolkit For Time Series Analysis"
    ]

--- a/chapter10/Chapter10.2.md
+++ b/chapter10/Chapter10.2.md
@@ -14,7 +14,7 @@ kernelspec:
 
 +++ {"id": "W_l-7O_Ed1MV"}
 
-[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter10/Chapter10.2.ipynb)
+[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter10/Chapter10.2.ipynb)
 
 # Modeling Toolkit For Time Series Analysis
 

--- a/chapter10/Chapter10.5.ipynb
+++ b/chapter10/Chapter10.5.ipynb
@@ -6,7 +6,7 @@
     "id": "9FuC628wBtGP"
    },
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter10/Chapter10.5.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter10/Chapter10.5.ipynb)\n",
     "\n",
     "# Analysis of Stochastic Processes"
    ]

--- a/chapter10/Chapter10.5.md
+++ b/chapter10/Chapter10.5.md
@@ -14,7 +14,7 @@ kernelspec:
 
 +++ {"id": "9FuC628wBtGP"}
 
-[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter10/Chapter10.5.ipynb)
+[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter10/Chapter10.5.ipynb)
 
 # Analysis of Stochastic Processes
 

--- a/chapter10/wavelets.ipynb
+++ b/chapter10/wavelets.ipynb
@@ -6,7 +6,7 @@
     "id": "BQtTNi7TAs0N"
    },
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter10/wavelets.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter10/wavelets.ipynb)\n",
     "\n",
     "## Wavelets\n",
     "An increasingly popular family of basis functions is called **wavelets**. By construction, wavelets are localized in both frequency and time domains. Individual wavelets are specified by a set of wavelet filter coefficients. Given a wavelet, a complete\n",

--- a/chapter5/AAS2019_ABCexample.ipynb
+++ b/chapter5/AAS2019_ABCexample.ipynb
@@ -8,7 +8,7 @@
     }
    },
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter5/AAS2019_ABCexample.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter5/AAS2019_ABCexample.ipynb)\n",
     "\n",
     "\n",
     "# Approximate Bayesian Computation Example\n",

--- a/chapter5/AAS2019_ABCexample.md
+++ b/chapter5/AAS2019_ABCexample.md
@@ -14,7 +14,7 @@ kernelspec:
 
 +++ {"slideshow": {"slide_type": "slide"}}
 
-[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter5/AAS2019_ABCexample.ipynb)
+[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter5/AAS2019_ABCexample.ipynb)
 
 
 # Approximate Bayesian Computation Example

--- a/chapter5/AAS2019_HBexample.ipynb
+++ b/chapter5/AAS2019_HBexample.ipynb
@@ -8,7 +8,7 @@
     }
    },
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter5/AAS2019_HBexample.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter5/AAS2019_HBexample.ipynb)\n",
     "\n",
     "# Hierarchical Bayes Example\n",
     "### January 6, 2020 \n",

--- a/chapter5/AAS2019_HBexample.md
+++ b/chapter5/AAS2019_HBexample.md
@@ -14,7 +14,7 @@ kernelspec:
 
 +++ {"slideshow": {"slide_type": "slide"}}
 
-[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter5/AAS2019_HBexample.ipynb)
+[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter5/AAS2019_HBexample.ipynb)
 
 # Hierarchical Bayes Example
 ### January 6, 2020 

--- a/chapter5/Figure5-10,11.ipynb
+++ b/chapter5/Figure5-10,11.ipynb
@@ -7,7 +7,7 @@
     "id": "K7l4AAzxVr-K"
    },
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter5/Figure5-10,11.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter5/Figure5-10,11.ipynb)\n",
     "\n",
     "\n",
     "# Parameter estimation for the Cauchy (Lorentzian) distribution"

--- a/chapter5/Figure5-10,11.md
+++ b/chapter5/Figure5-10,11.md
@@ -14,7 +14,7 @@ kernelspec:
 
 +++ {"id": "K7l4AAzxVr-K", "colab_type": "text"}
 
-[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter5/Figure5-10,11.ipynb)
+[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter5/Figure5-10,11.ipynb)
 
 
 # Parameter estimation for the Cauchy (Lorentzian) distribution

--- a/chapter5/Figure5-45678.ipynb
+++ b/chapter5/Figure5-45678.ipynb
@@ -7,7 +7,7 @@
     "id": "KA0JN-Zs1TeU"
    },
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter5/Figure5-45678.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter5/Figure5-45678.ipynb)\n",
     "\n",
     "# Parameter Estimation for a Gaussian Distribution"
    ]

--- a/chapter5/Figure5-45678.md
+++ b/chapter5/Figure5-45678.md
@@ -14,7 +14,7 @@ kernelspec:
 
 +++ {"id": "KA0JN-Zs1TeU", "colab_type": "text"}
 
-[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter5/Figure5-45678.ipynb)
+[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter5/Figure5-45678.ipynb)
 
 # Parameter Estimation for a Gaussian Distribution
 

--- a/chapter5/Figure5-9.ipynb
+++ b/chapter5/Figure5-9.ipynb
@@ -7,7 +7,7 @@
     "id": "THlMh2ywJFoq"
    },
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter5/Figure5-9.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter5/Figure5-9.ipynb)\n",
     "\n",
     "# Parameter Estimation for a Binomial Distribution"
    ]

--- a/chapter5/Figure5-9.md
+++ b/chapter5/Figure5-9.md
@@ -14,7 +14,7 @@ kernelspec:
 
 +++ {"id": "THlMh2ywJFoq", "colab_type": "text"}
 
-[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter5/Figure5-9.ipynb)
+[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter5/Figure5-9.ipynb)
 
 # Parameter Estimation for a Binomial Distribution
 

--- a/chapter6/Figure6-11.ipynb
+++ b/chapter6/Figure6-11.ipynb
@@ -7,7 +7,7 @@
     "id": "_aG935uWHf7s"
    },
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter6/Figure6-11.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter6/Figure6-11.ipynb)\n",
     "\n",
     "# Extreme Deconvolution"
    ]

--- a/chapter6/Figure6-11.md
+++ b/chapter6/Figure6-11.md
@@ -14,7 +14,7 @@ kernelspec:
 
 +++ {"id": "_aG935uWHf7s", "colab_type": "text"}
 
-[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter6/Figure6-11.ipynb)
+[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter6/Figure6-11.ipynb)
 
 # Extreme Deconvolution
 

--- a/chapter6/Figure6-347.ipynb
+++ b/chapter6/Figure6-347.ipynb
@@ -7,7 +7,7 @@
     "id": "sJsEWeS7YRRK"
    },
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter6/Figure6-347.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter6/Figure6-347.ipynb)\n",
     "\n",
     "# Density Estimation for SDSS \"Great Wall\""
    ]

--- a/chapter6/Figure6-6.ipynb
+++ b/chapter6/Figure6-6.ipynb
@@ -7,7 +7,7 @@
     "id": "XytOYGPU31rE"
    },
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter6/Figure6-6.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter6/Figure6-6.ipynb)\n",
     "\n",
     "# Gaussian Mixture Models Example"
    ]

--- a/chapter6/Figure6-6.md
+++ b/chapter6/Figure6-6.md
@@ -14,7 +14,7 @@ kernelspec:
 
 +++ {"id": "XytOYGPU31rE", "colab_type": "text"}
 
-[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter6/Figure6-6.ipynb)
+[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter6/Figure6-6.ipynb)
 
 # Gaussian Mixture Models Example
 

--- a/chapter6/Figure6.5.ipynb
+++ b/chapter6/Figure6.5.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter6/Figure6.5.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter6/Figure6.5.ipynb)\n",
     "\n",
     "# Searching for Structure in Point Data"
    ]

--- a/chapter6/Figure6.5.md
+++ b/chapter6/Figure6.5.md
@@ -12,7 +12,7 @@ kernelspec:
   name: python3
 ---
 
-[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter6/Figure6.5.ipynb)
+[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter6/Figure6.5.ipynb)
 
 # Searching for Structure in Point Data
 

--- a/chapter7/Dimensionality_reduction.ipynb
+++ b/chapter7/Dimensionality_reduction.ipynb
@@ -5,7 +5,7 @@
    "id": "convenient-bradley",
    "metadata": {},
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter7/Dimensionality_reduction.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter7/Dimensionality_reduction.ipynb)\n",
     "\n",
     "## Dimensionality reduction"
    ]

--- a/chapter8/astroml_regression_example.ipynb
+++ b/chapter8/astroml_regression_example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter8/astroml_regression_example.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter8/astroml_regression_example.ipynb)\n",
     "\n",
     "\n",
     "# Measurement Errors in Linear Regression"

--- a/chapter8/astroml_regression_example.md
+++ b/chapter8/astroml_regression_example.md
@@ -12,7 +12,7 @@ kernelspec:
   name: python3
 ---
 
-[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter8/astroml_regression_example.ipynb)
+[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter8/astroml_regression_example.ipynb)
 
 
 # Measurement Errors in Linear Regression

--- a/chapter8/astroml_regression_example_with_errors.ipynb
+++ b/chapter8/astroml_regression_example_with_errors.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter8/astroml_regression_example_with_errors.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter8/astroml_regression_example_with_errors.ipynb)\n",
     "\n",
     "# Measurement errors in both dependent and independent variables\n",
     "\n",

--- a/chapter8/astroml_regression_example_with_errors.md
+++ b/chapter8/astroml_regression_example_with_errors.md
@@ -12,7 +12,7 @@ kernelspec:
   name: python3
 ---
 
-[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter8/astroml_regression_example_with_errors.ipynb)
+[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter8/astroml_regression_example_with_errors.ipynb)
 
 # Measurement errors in both dependent and independent variables
 

--- a/chapter9/AAS2019_NNexample.ipynb
+++ b/chapter9/AAS2019_NNexample.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter9/AAS2019_NNexample.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter9/AAS2019_NNexample.ipynb)\n",
     "\n",
     "## Deep Learning: Classifying Astronomical Images \n",
     "\n",

--- a/chapter9/AAS2019_NNexample.md
+++ b/chapter9/AAS2019_NNexample.md
@@ -12,7 +12,7 @@ kernelspec:
   name: python3
 ---
 
-[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter9/AAS2019_NNexample.ipynb)
+[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter9/AAS2019_NNexample.ipynb)
 
 ## Deep Learning: Classifying Astronomical Images 
 

--- a/chapter9/classification.ipynb
+++ b/chapter9/classification.ipynb
@@ -5,7 +5,7 @@
    "id": "configured-prescription",
    "metadata": {},
    "source": [
-    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter9/classification.ipynb)\n",
+    "[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter9/classification.ipynb)\n",
     "\n",
     "## Classification"
    ]

--- a/chapter9/classification.md
+++ b/chapter9/classification.md
@@ -12,7 +12,7 @@ kernelspec:
   name: python3
 ---
 
-[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bsipocz/astroML-notebooks/notebooks?filepath=chapter9/classification.ipynb)
+[![Open in Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/astroML/astroML-notebooks/main?filepath=chapter9/classification.ipynb)
 
 ## Classification
 


### PR DESCRIPTION
Ideally, the links should be auto-generated (https://github.com/astroML/astroML-notebooks/issues/7), but for now they are hard-wired to the notebooks stored in the main repo.