### PR TITLE
Making sure colab links are made for notebooks

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -24,6 +24,10 @@ jobs:
           pip install -r .binder/requirements.txt -r doc-requirements.txt
 
 
+      - name: TMP: clean source files
+        # ugly hack to make the colab links work, sphinx defaults to use the md files to generate content, while the colab link can only be created from the ipynb
+        run: |
+          rm chapter*/astroml_chapter*md
       - name: Build the notebooks
         run: |
           sphinx-build -b html -D jupyter_execute_notebooks=off . _build/html

--- a/conf.py
+++ b/conf.py
@@ -59,7 +59,11 @@ html_theme_options = {
     "launch_buttons": {
         "binderhub_url": "https://mybinder.org",
         "colab_url": "https://colab.research.google.com"
+
     },
+    "home_page_in_toc": True,
+    "logo_link_url": "https://astroML.org",
+    "logo_url": "http://www.astroml.org/_images/plot_moving_objects_1.png"
 }
 
 

--- a/conf.py
+++ b/conf.py
@@ -48,7 +48,7 @@ execution_timeout = 900
 html_theme = 'sphinx_book_theme'
 html_title = 'AstroML Notebooks'
 html_logo = '_static/astroml_logo.gif'
-html_favicon = '_static/favicon.png'
+html_favicon = '_static/favicon.ico'
 html_theme_options = {
     "github_url": "https://github.com/astroML/astroML-notebooks",
     "repository_url": "https://github.com/astroML/astroML-notebooks",


### PR DESCRIPTION
Colab links are not generated in drop downs when both the md and ipynb version of the tutorials are available at rendering. This is a workaround until an upstream solution is available.

#23 however needs to be addressed, too as e.g. astroML is not available by default when opening a notebook in colab.