### PR TITLE
BUG: fix file download for DL notebook

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,11 +1,10 @@
 matplotlib
 numpy
 pymc3
-https://github.com/astroML/astroML/archive/main.zip
+astroML
 arviz
 seaborn
 jupyter-contrib-nbextensions
 tensorflow
-googledrivedownloader
 scipy
 scikit-learn<0.24    # Until https://github.com/astroML/astroML/pull/230 is released

--- a/chapter9/astroml_chapter9_Deep_Learning_Classifying_Astronomical_Images.ipynb
+++ b/chapter9/astroml_chapter9_Deep_Learning_Classifying_Astronomical_Images.ipynb
@@ -295,11 +295,41 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading file data/stamps_noise.npy.\n",
+      "File data/stamps_noise.npy is downloaded\n",
+      "Downloading file data/stamps_sources.npy.\n",
+      "File data/stamps_sources.npy is downloaded\n"
+     ]
+    }
+   ],
    "source": [
-    "from google_drive_downloader import GoogleDriveDownloader as gd\n",
-    "gd.download_file_from_google_drive(file_id='1UT2BCf-IDUEpvTmcU4bq6nDcY3Ayw5vJ', dest_path='./data/stamps_noise.npy', unzip=False)\n",
-    "gd.download_file_from_google_drive(file_id='1cZaMCA0z_nPX6GB_meLGouwOidEROcwc', dest_path='./data/stamps_sources.npy', unzip=False)"
+    "# Brute force direct downloads source and noise images to circumvent size limitations \n",
+    "# for google drive internal virus scan. Download may take some time.\n",
+    "\n",
+    "import os\n",
+    "import requests\n",
+    "\n",
+    "files = {'sources': (os.path.join('data', 'stamps_noise.npy'), '1UT2BCf-IDUEpvTmcU4bq6nDcY3Ayw5vJ'),\n",
+    "         'noise': (os.path.join('data', 'stamps_sources.npy'), '1cZaMCA0z_nPX6GB_meLGouwOidEROcwc')}\n",
+    "\n",
+    "for name, file_id in files.values():\n",
+    "    if not os.path.exists(name):\n",
+    "        print(f\"Downloading file {name}.\")\n",
+    "        \n",
+    "        os.makedirs(os.path.dirname(name), exist_ok=True)\n",
+    "        url = f\"https://docs.google.com/uc?export=download&id={file_id}&confirm=t\"\n",
+    "        response = requests.post(url)\n",
+    "        with open(name, 'wb') as file:\n",
+    "            file.write(response.content) \n",
+    "    print(f\"File {name} is downloaded\")\n",
+    "            \n",
+    "sources = np.load(files['sources'][0])\n",
+    "noise = np.load(files['noise'][0])"
    ]
   },
   {
@@ -308,13 +338,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "#read in source and noise images\n",
-    "path = './data/'\n",
-    "sources = np.load(path+'stamps_sources.npy')\n",
-    "noise = np.load(path+'stamps_noise.npy')\n",
+    "# normalizing images\n",
     "\n",
     "point_source_stamps = []\n",
     "for image in sources:\n",
@@ -356,7 +380,9 @@
     }
    ],
    "source": [
-    "#plot sample of images\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# plot sample of images\n",
     "plot_image_array(no_point_source_stamps, title='false positives')\n",
     "plot_image_array(point_source_stamps, title='true positives')"
    ]

--- a/chapter9/astroml_chapter9_Deep_Learning_Classifying_Astronomical_Images.ipynb
+++ b/chapter9/astroml_chapter9_Deep_Learning_Classifying_Astronomical_Images.ipynb
@@ -147,7 +147,6 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
     "from astroML.utils import split_samples\n",
     "%matplotlib inline"
@@ -380,8 +379,6 @@
     }
    ],
    "source": [
-    "import matplotlib.pyplot as plt\n",
-    "\n",
     "# plot sample of images\n",
     "plot_image_array(no_point_source_stamps, title='false positives')\n",
     "plot_image_array(point_source_stamps, title='true positives')"
@@ -526,9 +523,7 @@
     "from tensorflow.keras.models import Sequential\n",
     "from tensorflow.keras.layers import Dense, Conv2D, Flatten, Activation\n",
     "from tensorflow.keras.utils import to_categorical\n",
-    "import matplotlib.pyplot as plt\n",
     "\n",
-    "import numpy as np\n",
     "def simple(input_shape=(21, 21, 1), n_classes: int = 2):\n",
     "\n",
     "    model = tf.keras.models.Sequential(name='simple')\n",
@@ -945,9 +940,7 @@
     "from tensorflow.keras.models import Sequential\n",
     "from tensorflow.keras.layers import Dense, Conv2D, Flatten\n",
     "from tensorflow.keras.utils import to_categorical\n",
-    "import matplotlib.pyplot as plt\n",
     "\n",
-    "import numpy as np\n",
     "def vgg6(input_shape=(21, 21, 1), n_classes: int = 2):\n",
     "    \"\"\"\n",
     "        VGG6\n",
@@ -1262,7 +1255,6 @@
    "outputs": [],
    "source": [
     "# Based on https://github.com/priya-dwivedi/Deep-Learning/blob/master/resnet_keras/Residual_Networks_yourself.ipynb\n",
-    "import numpy as np\n",
     "import tensorflow as tf\n",
     "from tensorflow.keras.layers import Input, Add, Dense, Activation, ZeroPadding2D, BatchNormalization, Flatten, Conv2D, AveragePooling2D, MaxPooling2D, GlobalMaxPooling2D\n",
     "from tensorflow.keras.initializers import glorot_uniform\n",

--- a/chapter9/astroml_chapter9_Deep_Learning_Classifying_Astronomical_Images.md
+++ b/chapter9/astroml_chapter9_Deep_Learning_Classifying_Astronomical_Images.md
@@ -100,7 +100,6 @@ device_lib.list_local_devices()
 
 ```{code-cell} ipython3
 import numpy as np
-import pandas as pd
 import matplotlib.pyplot as plt
 from astroML.utils import split_samples
 %matplotlib inline
@@ -267,8 +266,6 @@ for image in noise:
 ```
 
 ```{code-cell} ipython3
-import matplotlib.pyplot as plt
-
 # plot sample of images
 plot_image_array(no_point_source_stamps, title='false positives')
 plot_image_array(point_source_stamps, title='true positives')
@@ -376,9 +373,7 @@ import tensorflow as tf
 from tensorflow.keras.models import Sequential
 from tensorflow.keras.layers import Dense, Conv2D, Flatten, Activation
 from tensorflow.keras.utils import to_categorical
-import matplotlib.pyplot as plt
 
-import numpy as np
 def simple(input_shape=(21, 21, 1), n_classes: int = 2):
 
     model = tf.keras.models.Sequential(name='simple')
@@ -567,9 +562,7 @@ import tensorflow as tf
 from tensorflow.keras.models import Sequential
 from tensorflow.keras.layers import Dense, Conv2D, Flatten
 from tensorflow.keras.utils import to_categorical
-import matplotlib.pyplot as plt
 
-import numpy as np
 def vgg6(input_shape=(21, 21, 1), n_classes: int = 2):
     """
         VGG6
@@ -703,7 +696,6 @@ ax.imshow(np.array(heatmap), alpha=0.5, cmap=mycmap)
 
 ```{code-cell} ipython3
 # Based on https://github.com/priya-dwivedi/Deep-Learning/blob/master/resnet_keras/Residual_Networks_yourself.ipynb
-import numpy as np
 import tensorflow as tf
 from tensorflow.keras.layers import Input, Add, Dense, Activation, ZeroPadding2D, BatchNormalization, Flatten, Conv2D, AveragePooling2D, MaxPooling2D, GlobalMaxPooling2D
 from tensorflow.keras.initializers import glorot_uniform


### PR DESCRIPTION
The file download cell run into issues due to size limitations for google drive virusscan. Instead of a third package library we now brute force direct download the files.

(note: I currently have some issues to locally run tensorflow (it crashed on import, with multiple python versions, etc.), the executed content of the notebook thus kept the same as it was before, and made a note that we probably need to pin a version number for TF, or check whether it may have an issue with M1 processors, see #35)

cc @connolly - please check whether this works for you