### PR TITLE
BUG: fix latex rendering of math: one should read the myst-parser changelog

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -28,6 +28,10 @@ extensions = [
     'sphinx_copybutton',
 ]
 
+myst_enable_extensions = [
+    'dollarmath',
+]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
At the end there is no mystery involved by by upgrading laptops, one should just read the release notes:

https://myst-parser.readthedocs.io/en/latest/develop/_changelog.html#dollarmath-is-now-disabled-by-default