### PR TITLE
Adding latex dependencies for binder apt install config

### DIFF
--- a/.binder/apt.txt
+++ b/.binder/apt.txt
@@ -1,0 +1,5 @@
+texlive
+texlive-latex-extra
+texlive-fonts-recommended
+dvipng
+cm-super


### PR DESCRIPTION
We should make sure that the latex dependencies are installed on binder, otherwise exceptions will be raised.

This should most likely fix the issue #54, but it has to be checked after merging (binder is not picking up changes in PRs, we have to get the change onto the main branch first)