### PR TITLE
CI: render in the figure from the notebooks

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -25,6 +25,11 @@ jobs:
         run: |
           pip install -r .binder/requirements.txt -r doc-requirements.txt
 
+      - name: TMP clean MD source files
+        # sphinx defaults to use the md files to generate content
+        # revisit these issues upstream, or enable executing for the simpler notebooks.
+        run: |
+            find chapter* -name "*ipynb"|awk -F ipynb '{print $1"md"}'|xargs rm -f
 
       - name: Build the notebooks
         run: |

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -14,10 +14,10 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 


### PR DESCRIPTION
We should execute the simpler notebooks in CI, but this makes sure that in the meantime we render the figures into the deployed HTML pages