### PR TITLE
MAINT: pin sphinx version

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx<5
 myst-nb
 sphinx-book-theme
 sphinx-copybutton


### PR DESCRIPTION
executable books are not yet sphinx5 compatible, this patch helps the version resolution for pip and fixes the currently failing CI